### PR TITLE
Fix: Version of MultiBot.Run not showing

### DIFF
--- a/SelectMultiBotRun.au3
+++ b/SelectMultiBotRun.au3
@@ -904,7 +904,7 @@ Func GetBotVers()
 		$hBotVers = FileOpen($g_sIniDir & "\multibot.run.au3")
 
 		$sBotVers = FileRead($hBotVers)
-		$aBotVers = StringRegExp($sBotVers, "(?i)v([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})", 2)
+		$aBotVers = StringRegExp($sBotVers, "(?i)v([0-9]+)(?:\.[0-9]+)?(?:\.[0-9]+)?", 2)
 
 		FileClose($hBotVers)
 		If $aSections[$i] <> "Options" Then
@@ -914,7 +914,7 @@ Func GetBotVers()
 				$hBotVers = FileOpen($g_sIniDir & "\multibot.run.version.au3")
 
 				$sBotVers = FileRead($hBotVers)
-				$aBotVers = StringRegExp($sBotVers, "(?i)v([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})", 2)
+				$aBotVers = StringRegExp($sBotVers, "(?i)v([0-9]+)(?:\.[0-9]+)?(?:\.[0-9]+)?", 2)
 
 				FileClose($hBotVers)
 				If IsArray($aBotVers) Then IniWrite($g_sDirProfiles, $aSections[$i], "BotVers", $aBotVers[0])


### PR DESCRIPTION
There were some changes in multibot.run.version.au3. 
Now SelectMultiBotRun shows the correct version of MultiBot.Run.